### PR TITLE
Add Position and Len for flac

### DIFF
--- a/flac/decode.go
+++ b/flac/decode.go
@@ -56,6 +56,7 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 			// refill buffer.
 			if err := d.refill(); err != nil {
 				d.err = err
+				d.pos += n
 				return n, n > 0
 			}
 			j = 0

--- a/flac/decode.go
+++ b/flac/decode.go
@@ -41,6 +41,7 @@ type decoder struct {
 	rc     io.ReadCloser
 	stream *flac.Stream
 	buf    [][2]float64
+	pos    int
 	err    error
 }
 
@@ -64,6 +65,7 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		n++
 	}
 	d.buf = d.buf[j:]
+	d.pos += n
 	return n, true
 }
 
@@ -128,11 +130,11 @@ func (d *decoder) Err() error {
 }
 
 func (d *decoder) Len() int {
-	panic("not yet implemented")
+	return int(d.stream.Info.NSamples)
 }
 
 func (d *decoder) Position() int {
-	panic("not yet implemented")
+	return d.pos
 }
 
 func (d *decoder) Seek(p int) error {


### PR DESCRIPTION
d.stream.Info.NSamples is uint64 so calling
int() on it could result in an overflow.  I
have no idea how likely that is, but if it happens
then Position() will return -1.

I also don't know if this PR is the intent behind the beep.StreamSeeker interface, but it's working great for the app that I built using beep.