### PR TITLE
effects: add Mono and Swap effects

### DIFF
--- a/effects/mono.go
+++ b/effects/mono.go
@@ -1,0 +1,24 @@
+package effects
+
+import "github.com/faiface/beep"
+
+// Mono converts the wrapped Streamer to a mono buffer
+// by downmixing the left and right channels together.
+type Mono struct {
+	Streamer beep.Streamer
+}
+
+// Stream streams the wrapped Streamer while converting the channels into mono.
+func (m *Mono) Stream(samples [][2]float64) (n int, ok bool) {
+	n, ok = m.Streamer.Stream(samples)
+	for i := range samples[:n] {
+		mix := (samples[i][0] + samples[i][1]) / 2
+		samples[i][0], samples[i][1] = mix, mix
+	}
+	return n, ok
+}
+
+// Err propagates the wrapped Streamer's errors.
+func (m *Mono) Err() error {
+	return m.Streamer.Err()
+}

--- a/effects/swap.go
+++ b/effects/swap.go
@@ -1,0 +1,23 @@
+package effects
+
+import "github.com/faiface/beep"
+
+// Swap swaps the left and right channel of the wrapped Streamer.
+type Swap struct {
+	Streamer beep.Streamer
+}
+
+// Stream streams the wrapped Streamer while having its left and right
+// channels swapped.
+func (s *Swap) Stream(samples [][2]float64) (n int, ok bool) {
+	n, ok = s.Streamer.Stream(samples)
+	for i := range samples[:n] {
+		samples[i][0], samples[i][1] = samples[i][1], samples[i][0]
+	}
+	return n, ok
+}
+
+// Err propagates the wrapped Streamer's errors.
+func (s *Swap) Err() error {
+	return s.Streamer.Err()
+}


### PR DESCRIPTION
This commit adds two different effects, namely `Mono`, that combines the
L/R channels and mix it down into a single channel, and `Swap` that
simply swap the L/R channel outputs.