### PR TITLE
Add support for decoding 24bits wave file

### DIFF
--- a/wav/decode.go
+++ b/wav/decode.go
@@ -139,8 +139,8 @@ func Decode(rc io.ReadCloser) (s beep.StreamSeekCloser, format beep.Format, err 
 	if d.h.NumChans <= 0 {
 		return nil, beep.Format{}, errors.New("wav: invalid number of channels (less than 1)")
 	}
-	if d.h.BitsPerSample != 8 && d.h.BitsPerSample != 16 {
-		return nil, beep.Format{}, errors.New("wav: unsupported number of bits per sample, 8 or 16 are supported")
+	if d.h.BitsPerSample != 8 && d.h.BitsPerSample != 16 && d.h.BitsPerSample != 24 {
+		return nil, beep.Format{}, errors.New("wav: unsupported number of bits per sample, 8 or 16 or 24 are supported")
 	}
 	format = beep.Format{
 		SampleRate:  beep.SampleRate(d.h.SampleRate),
@@ -233,6 +233,17 @@ func (d *decoder) Stream(samples [][2]float64) (n int, ok bool) {
 		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
 			samples[j][0] = float64(int16(p[i+0])+int16(p[i+1])*(1<<8)) / (1<<15 - 1)
 			samples[j][1] = float64(int16(p[i+2])+int16(p[i+3])*(1<<8)) / (1<<15 - 1)
+		}
+	case d.h.BitsPerSample == 24 && d.h.NumChans >= 1:
+		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
+			val := float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23 - 1)
+			samples[j][0] = val
+			samples[j][1] = val
+		}
+	case d.h.BitsPerSample == 24 && d.h.NumChans >= 2:
+		for i, j := 0, 0; i <= n-bytesPerFrame; i, j = i+bytesPerFrame, j+1 {
+			samples[j][0] = float64((int32(p[i+0])<<8)+(int32(p[i+1])<<16)+(int32(p[i+2])<<24)) / (1 << 8) / (1<<23 - 1)
+			samples[j][1] = float64((int32(p[i+3])<<8)+(int32(p[i+4])<<16)+(int32(p[i+5])<<24)) / (1 << 8) / (1<<23 - 1)
 		}
 	}
 	d.pos += int32(n)

--- a/wav/encode.go
+++ b/wav/encode.go
@@ -23,8 +23,8 @@ func Encode(w io.WriteSeeker, s beep.Streamer, format beep.Format) (err error) {
 	if format.NumChannels <= 0 {
 		return errors.New("wav: invalid number of channels (less than 1)")
 	}
-	if format.Precision != 1 && format.Precision != 2 {
-		return errors.New("wav: unsupported precision, 1 or 2 is supported")
+	if format.Precision != 1 && format.Precision != 2 && format.Precision != 3 {
+		return errors.New("wav: unsupported precision, 1, 2 or 3 is supported")
 	}
 
 	h := header{
@@ -63,7 +63,7 @@ func Encode(w io.WriteSeeker, s beep.Streamer, format beep.Format) (err error) {
 			for _, sample := range samples[:n] {
 				buf = buf[format.EncodeUnsigned(buf, sample):]
 			}
-		case format.Precision == 2:
+		case format.Precision == 2 || format.Precision == 3:
 			for _, sample := range samples[:n] {
 				buf = buf[format.EncodeSigned(buf, sample):]
 			}


### PR DESCRIPTION
This commit added 24-bits wave file support to decoder. However, encoder was not implemented since it's necessary to change the structure of `Format` to do it.