### PR TITLE
Fixed buffer pop # of samples instead of bytes.

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -186,7 +186,7 @@ func (b *Buffer) Len() int {
 //
 // Existing Streamers are not affected.
 func (b *Buffer) Pop(n int) {
-	b.data = b.data[n:]
+	b.data = b.data[n*b.f.Width():]
 }
 
 // Append adds all audio data from the given Streamer to the end of the Buffer.

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -59,3 +59,29 @@ func TestFormatEncodeDecode(t *testing.T) {
 		}
 	}
 }
+
+func TestBufferAppendPop(t *testing.T) {
+	formats := make(chan beep.Format)
+	go func() {
+		defer close(formats)
+		for _, numChannels := range []int{1, 2, 3, 4} {
+			formats <- beep.Format{
+				SampleRate:  44100,
+				NumChannels: numChannels,
+				Precision:   2,
+			}
+		}
+	}()
+
+	for format := range formats {
+		b := beep.NewBuffer(format)
+		b.Append(beep.Silence(768))
+		if b.Len() != 768 {
+			t.Fatalf("buffer length isn't equal to appended stream length: expected: %v, actual: %v (NumChannels: %v)", 768, b.Len(), format.NumChannels)
+		}
+		b.Pop(512)
+		if b.Len() != 768-512 {
+			t.Fatalf("buffer length isn't as expected after Pop: expected: %v, actual: %v (NumChannels: %v)", 768-512, b.Len(), format.NumChannels)
+		}
+	}
+}


### PR DESCRIPTION
In response to [this](https://github.com/faiface/beep/issues/63) issue.