### PR TITLE
flac,wav: relax Decode input to support io.Reader without Close method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,3 @@ require (
 	github.com/mewkiz/flac v1.0.5
 	github.com/pkg/errors v0.8.1
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/mewkiz/flac v1.0.5
 	github.com/pkg/errors v0.8.1
 )
+
+go 1.13


### PR DESCRIPTION
The motivating reason to relax the input parameter to Decode is
to allow for bytes.Buffer and bufio.Reader to be used, both of
which are lacking a Close method.

Calling Close on the returned beep.StreamSeekCloser is a nop on the
underlying io.Reader the supplied reader to Decode is lacking a
Close method.