### PR TITLE
Update decode.go

### DIFF
--- a/wav/decode.go
+++ b/wav/decode.go
@@ -121,6 +121,9 @@ func Decode(r io.Reader) (s beep.StreamSeekCloser, format beep.Format, err error
 			if err := binary.Read(r, binary.LittleEndian, &fs); err != nil {
 				return nil, beep.Format{}, errors.Wrap(err, "wav: missing unknown chunk size")
 			}
+			if fs % 2 != 0 {
+				fs = fs + 1
+			}
 			trash := make([]byte, fs)
 			if err := binary.Read(r, binary.LittleEndian, trash); err != nil {
 				return nil, beep.Format{}, errors.Wrap(err, "wav: missing unknown chunk body")


### PR DESCRIPTION
From https://sites.google.com/site/musicgapi/technical-documents/wav-file-format.


> One tricky thing about RIFF file chunks is that they must be word aligned. This means that their total size must be a multiple of 2 bytes (ie. 2, 4, 6, 8, and so on). If a chunk contains an odd number of data bytes, causing it not to be word aligned, an extra padding byte with a value of zero must follow the last data byte. This extra padding byte is not counted in the chunk size,  therefor a program must always word align a chunk headers size value in order to calculate the offset of the following chunk. 
