### PR TITLE
support malgo as under the hood library for playing audio

### DIFF
--- a/examples/select-device/main.go
+++ b/examples/select-device/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/faiface/beep"
+	"github.com/faiface/beep/mp3"
+	"github.com/faiface/beep/speaker"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s song.mp3\n", os.Args[0])
+		os.Exit(1)
+	}
+	f, err := os.Open(os.Args[1])
+	if err != nil {
+		report(err)
+	}
+	streamer, format, err := mp3.Decode(f)
+	if err != nil {
+		report(err)
+	}
+	defer streamer.Close()
+
+	deviceSelect := func(deviceList []speaker.SpeakerDevice) *speaker.SpeakerDevice {
+		for {
+			fmt.Printf("choose a device from the list:\n")
+			fmt.Println("0: default device")
+			for i, d := range deviceList {
+				fmt.Printf("%d: %s\n", i+1, d.Name)
+			}
+
+			var sindex string
+			_, err := fmt.Scanf("%s\n", &sindex)
+			if err != nil {
+				fmt.Println("invalid selection, try again...")
+				continue
+			}
+			if sindex == "q" {
+				os.Exit(0)
+			}
+			index, _ := strconv.Atoi(sindex)
+			if index > len(deviceList) {
+				fmt.Printf("invalid selection [%d], try again...\n", index)
+				continue
+			}
+			if index == 0 {
+				return nil
+			}
+			return &deviceList[index-1]
+		}
+	}
+	speaker.InitDeviceSelection(format.SampleRate, format.SampleRate.N(time.Second/10), deviceSelect)
+
+	done := make(chan bool)
+	speaker.Play(beep.Seq(streamer, beep.Callback(func() {
+		done <- true
+	})))
+
+	<-done
+}
+
+func report(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/examples/select-device/readme.md
+++ b/examples/select-device/readme.md
@@ -1,0 +1,9 @@
+this is an example using the malgo as unerlying subsystem instead of oto
+
+to build locally, follow these steps:
+```bash
+go mod init select-device
+go mod edit -replace github.com/faiface/beep=/path/to/local/src/beep
+go mod tidy
+go build -tags malgo
+```

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ go 1.14
 
 require (
 	github.com/gdamore/tcell v1.3.0
+	github.com/gen2brain/malgo v0.10.35
 	github.com/hajimehoshi/go-mp3 v0.3.0
 	github.com/hajimehoshi/oto v0.7.1
 	github.com/jfreymuth/oggvorbis v1.0.1
 	github.com/mewkiz/flac v1.0.7
 	github.com/pkg/errors v0.9.1
+	github.com/sheerun/queue v1.0.1
+	github.com/stretchr/testify v1.7.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,5 @@ require (
 	github.com/jfreymuth/oggvorbis v1.0.1
 	github.com/mewkiz/flac v1.0.7
 	github.com/pkg/errors v0.9.1
-	github.com/sheerun/queue v1.0.1
 	github.com/stretchr/testify v1.7.1 // indirect
 )

--- a/speaker/speaker_malgo.go
+++ b/speaker/speaker_malgo.go
@@ -6,7 +6,6 @@ package speaker
 
 import (
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/faiface/beep"
@@ -111,7 +110,6 @@ func InitDeviceSelection(sampleRate beep.SampleRate, bufferSize int, cb chooseDe
 	player, err = malgo.InitDevice(context.Context, deviceConfig, deviceCallbacks)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize speaker (player)")
-		os.Exit(1)
 	}
 
 	err = player.Start()


### PR DESCRIPTION
[malgo](https://github.com/gen2brain/malgo) is go binding library for [miniaudio](https://miniaud.io) that support device selection and some more features.
enable beep to use malgo library as apeaker interface,  use `-tags malgo` when building to utilize the malgo library.
follow the `examples/select-device` example to see how to utilize device selection